### PR TITLE
Remove 'ui_accept' to exit gameplay Scene

### DIFF
--- a/gameplay/gameplay.gd
+++ b/gameplay/gameplay.gd
@@ -1,9 +1,6 @@
 extends Node2D
 
 func _process(_delta: float) -> void:
-	if Input.is_action_pressed("ui_accept"):
-		get_tree().change_scene_to_file(Global.SCENE_MAIN_MENU)
-
 	$Icon.rotate(_delta)
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
First off, thanks for the project skeleton.

This interaction surprised me. In fact, I worked on a project based on this skeleton for a few hours before I dug into
why this strange behavior was happening and realized it's just a line of code in the _process function!

For clarity, I would suggest either (1) removing this logic (this PR) or (2) explaining it in the UI, as you have for the Pause Menu interaction.

Thanks!
